### PR TITLE
Set correct locale for endpoints

### DIFF
--- a/src/api/index.php
+++ b/src/api/index.php
@@ -3,6 +3,7 @@
 require_once __DIR__.'/common/api.php';
 require_once __DIR__.'/common/Endpoint.php';
 require_once __DIR__.'/common/validate.php';
+require_once __DIR__.'/../config/init.php';
 require_once __DIR__.'/../utils/auth/StravaUtils.php';
 require_once __DIR__.'/../utils/session/StandardSession.php';
 


### PR DESCRIPTION
This should fix month names being in English in notification messages.